### PR TITLE
This Nginx RPM on RHEL 7 doesn't use the Sys V/init.d approach, given th...

### DIFF
--- a/nginx_spec/nginx.spec.template
+++ b/nginx_spec/nginx.spec.template
@@ -256,7 +256,6 @@ install -p -D -m 0644 %{SOURCE14} %{buildroot}%{_mandir}/man8/nginx-upgrade.8
 
 sed -i 's|/var/run|/run|g' \
     %{buildroot}%{nginx_confdir}/nginx.conf \
-    %{buildroot}%{_initrddir}/nginx \
     %{buildroot}%{_sysconfdir}/logrotate.d/nginx
 %endif
 


### PR DESCRIPTION
...is SED call is only execute for RRHEL 17 or Fedora >16, shouldn't this be removed?