### PR TITLE
add vendor and packager info

### DIFF
--- a/specs/nginx/nginx.spec.erb
+++ b/specs/nginx/nginx.spec.erb
@@ -44,6 +44,8 @@ Group:             System Environment/Daemons
 # http://www.freebsd.org/copyright/freebsd-license.html
 License:           BSD
 URL:               http://nginx.org/
+Packager:          Phusion
+Vendor:            Phusion
 
 Source0:           http://nginx.org/download/nginx-%{version}.tar.gz
 Source1:           http://nginx.org/download/nginx-%{version}.tar.gz.asc

--- a/specs/passenger/passenger.spec.erb
+++ b/specs/passenger/passenger.spec.erb
@@ -54,6 +54,8 @@ Group: System Environment/Daemons
 # See: https://bugzilla.redhat.com/show_bug.cgi?id=470696#c146
 License: Boost and BSD and BSD with advertising and MIT and zlib
 URL: https://www.phusionpassenger.com
+Vendor: Phusion
+Packager: Phusion
 
 Source: http://s3.amazonaws.com/phusion-passenger/releases/%{tarball_name}-%{tarball_version}.tar.gz
 Source1: http://nginx.org/download/nginx-%{nginx_version}.tar.gz


### PR DESCRIPTION
For your official RPM packages, is it possible to include the Vendor and Packager fields? It is usually added, and would be handy for identifying the package source with, e.g., `rpm -qi passenger` (though yum info will typically show what repo the package came from).

```
# rpm -qi nginx
Name        : nginx
Epoch       : 1
Version     : 1.10.1
Release     : 8.p5.0.30.el7
Architecture: x86_64
Install Date: Wed 21 Sep 2016 02:11:09 PM PDT
Group       : System Environment/Daemons
Size        : 2354706
License     : BSD
Signature   : (none)
Source RPM  : nginx-1.10.1-8.p5.0.30.el7.src.rpm
Build Date  : Mon 25 Jul 2016 01:41:40 PM PDT
Build Host  : e71a2d0749bb
Relocations : (not relocatable)
URL         : http://nginx.org/
Summary     : A high performance web server and reverse proxy server
Description :
Nginx is a web server and a reverse proxy server for HTTP, SMTP, POP3 and
IMAP protocols, with a strong focus on high concurrency, performance and low
memory usage. Includes Phusion Passenger support.
# rpm -qi passenger
Name        : passenger
Version     : 5.0.30
Release     : 8.el7
Architecture: x86_64
Install Date: Wed 14 Sep 2016 03:58:20 PM PDT
Group       : System Environment/Daemons
Size        : 6036436
License     : Boost and BSD and BSD with advertising and MIT and zlib
Signature   : (none)
Source RPM  : passenger-5.0.30-8.el7.src.rpm
Build Date  : Mon 25 Jul 2016 01:45:55 PM PDT
Build Host  : e71a2d0749bb
Relocations : (not relocatable)
URL         : https://www.phusionpassenger.com
Summary     : Phusion Passenger application server
Description :
Phusion Passenger® is a web server and application server, designed to be fast,
robust and lightweight. It takes a lot of complexity out of deploying web apps,
adds powerful enterprise-grade features that are useful in production,
and makes administration much easier and less complex. It supports Ruby,
Python, Node.js and Meteor.
```

vs. 

```
# rpm -qi nginx
Name        : nginx
Epoch       : 1
Version     : 1.10.1
Release     : 1.el7
Architecture: x86_64
Install Date: Thu 22 Sep 2016 03:33:10 PM PDT
Group       : System Environment/Daemons
Size        : 1457649
License     : BSD
Signature   : RSA/SHA256, Sat 02 Jul 2016 10:23:36 PM PDT, Key ID 6a2faea2352c64e5
Source RPM  : nginx-1.10.1-1.el7.src.rpm
Build Date  : Sat 02 Jul 2016 12:43:29 PM PDT
Build Host  : buildvm-12.phx2.fedoraproject.org
Relocations : (not relocatable)
Packager    : Fedora Project
Vendor      : Fedora Project
URL         : http://nginx.org/
Summary     : A high performance web server and reverse proxy server
Description :
Nginx is a web server and a reverse proxy server for HTTP, SMTP, POP3 and
IMAP protocols, with a strong focus on high concurrency, performance and low
memory usage.
```
